### PR TITLE
DOC: show that S-waves reduce to flat distribution

### DIFF
--- a/docs/gluex-amplitude.ipynb
+++ b/docs/gluex-amplitude.ipynb
@@ -87,6 +87,7 @@
    },
    "outputs": [],
    "source": [
+    "from sympy.printing.precedence import PRECEDENCE\n",
     "from sympy.printing.printer import Printer\n",
     "\n",
     "\n",
@@ -96,6 +97,7 @@
     "    return f\"{base}_{{{indices}}}\"\n",
     "\n",
     "\n",
+    "sp.Indexed.precedence = PRECEDENCE[\"Pow\"] - 1\n",
     "sp.Indexed._latex = _print_Indexed_latex\n",
     "Printer._global_settings[\"gothic_re_im\"] = True"
    ]


### PR DESCRIPTION
See [commit history](https://github.com/redeboer/gluex-amplitude/pull/5/commits) for additional improvements.

![image](https://github.com/redeboer/gluex-amplitude/assets/29308176/16c9080d-d71a-4e38-a08e-d7c71c226bf8)
