### PR TITLE
ENH: use JAX as computational backend

### DIFF
--- a/docs/gluex-amplitude.ipynb
+++ b/docs/gluex-amplitude.ipynb
@@ -352,11 +352,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import jax\n",
+    "\n",
     "free_symbols = sorted(intensity_expr.doit().free_symbols, key=str)\n",
     "amp_symbols = [s for s in free_symbols if isinstance(s, sp.Indexed)]\n",
     "arguments = (theta, phi, Phi, Py, *amp_symbols)\n",
     "plotted_expr = intensity_expr.doit().xreplace({kappa: sp.pi}).expand(func=True)\n",
-    "intensity_func = sp.lambdify(arguments, plotted_expr, \"numpy\", cse=True)\n",
+    "intensity_func = sp.lambdify(arguments, plotted_expr, \"jax\", cse=True)\n",
+    "intensity_func = jax.jit(intensity_func)\n",
     "intensity_func"
    ]
   },
@@ -375,7 +378,7 @@
    },
    "outputs": [],
    "source": [
-    "import numpy as np\n",
+    "import jax.numpy as np\n",
     "\n",
     "cos_theta_array, phi_array = np.meshgrid(\n",
     "    np.linspace(-1, +1, num=200),\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "jax",
     "jaxlib",
     "matplotlib",
-    "sympy>=1.11",
+    "sympy>=1.11", # https://github.com/sympy/sympy/wiki/release-notes-for-1.11
 ]
 name = "gluex-amplitude"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ dependencies = [
     "ipympl",
     "ipywidgets",
     "ipywidgets",
+    "jax",
+    "jaxlib",
     "matplotlib",
-    "sympy",
+    "sympy>=1.11",
 ]
 name = "gluex-amplitude"
 requires-python = ">=3.7"


### PR DESCRIPTION
As a follow-up to #8, this PR shows how to switch to JAX (see [diff](https://github.com/redeboer/gluex-amplitude/pull/10/files)). For now, the notebook uses pure SymPy, without TensorWaves' [`create_parametrized_function()`](https://tensorwaves.readthedocs.io/en/0.4.x/api/tensorwaves.function.sympy.html#tensorwaves.function.sympy.create_parametrized_function) (which is more suited for [fitting](https://tensorwaves.readthedocs.io/en/0.4.x/amplitude-analysis.html#optimize-fit-parameters)).